### PR TITLE
Add movement logs page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import ImageUpload from './components/ImageUpload';
 import Resizer from 'react-image-file-resizer';
 import ImageModal from './components/ImageModal';
 
+import { useNavigate } from "react-router-dom";
 const TrashIcon = ({ size = 20, color = "#e74c3c" }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
     <path d="M3 6h18" stroke={color} strokeWidth="2" strokeLinecap="round"/>
@@ -11,6 +12,7 @@ const TrashIcon = ({ size = 20, color = "#e74c3c" }) => (
 );
 
 function App() {
+  const navigate = useNavigate();
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [ads, setAds] = useState([]);
   const [adsLoading, setAdsLoading] = useState(false);
@@ -142,7 +144,10 @@ function App() {
         background: 'white', maxWidth: 700, margin: 'auto',
         borderRadius: 16, boxShadow: '0 4px 24px #0001', padding: 32
       }}>
-        <h2 style={{fontWeight: 800, fontSize: 28, letterSpacing: 1}}>Ad Display Portal</h2>
+          <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+            <h2 style={{fontWeight: 800, fontSize: 28, letterSpacing: 1}}>Ad Display Portal</h2>
+            <button type="button" onClick={() => navigate("/movement-logs")} style={{background:"#fff", color:"#006cff", border:"1px solid #006cff", padding:"6px 12px", borderRadius:6, fontWeight:600, cursor:"pointer"}}>App Logs</button>
+          </div>
         <form onSubmit={handleSubmit}>
           <div style={{marginBottom: 16}}>
             <label style={{fontWeight: 600}}>Ad Title *</label>

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import App from './App';
+import MovementLogs from './pages/MovementLogs';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/movement-logs" element={<MovementLogs />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/MovementLogs.js
+++ b/src/pages/MovementLogs.js
@@ -1,0 +1,81 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+function MovementLogs() {
+  const [logs, setLogs] = useState([]);
+  const [running, setRunning] = useState(false);
+  const intervalRef = useRef(null);
+
+  const fetchLogs = async () => {
+    try {
+      const res = await fetch('https://ad-display-backend.onrender.com/api/logs');
+      const data = await res.json();
+      if (Array.isArray(data)) {
+        setLogs(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch logs', err);
+    }
+  };
+
+  const startLogs = () => {
+    if (intervalRef.current) return;
+    fetchLogs();
+    intervalRef.current = setInterval(fetchLogs, 500);
+    setRunning(true);
+  };
+
+  const stopLogs = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setRunning(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Movement Logs</h2>
+      <div style={{ marginBottom: 10 }}>
+        <button onClick={startLogs} disabled={running} style={{ marginRight: 10 }}>
+          Start
+        </button>
+        <button onClick={stopLogs} disabled={!running}>
+          Stop
+        </button>
+      </div>
+      <div
+        style={{
+          background: '#f7f7f7',
+          padding: 10,
+          border: '1px solid #ddd',
+          borderRadius: 4,
+          maxHeight: 400,
+          overflowY: 'auto',
+        }}
+      >
+        {logs.length === 0 ? (
+          <div>No logs</div>
+        ) : (
+          logs.map((log) => (
+            <div key={log.id} style={{ marginBottom: 4 }}>
+              <span style={{ color: '#555' }}>
+                {new Date(log.createdAt._seconds * 1000).toLocaleString()} - {log.level}
+              </span>{' '}
+              {log.message}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MovementLogs;


### PR DESCRIPTION
## Summary
- add routing and MovementLogs page for app logs
- show Start and Stop buttons to poll logs
- add navigation button to view logs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853cfd13000832d8c21c298704f78f7